### PR TITLE
Add dev repl to npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "repl": "ts-node scripts/dev-repl.ts",
     "dev": "ts-node-dev --exit-child src/index.ts",
     "start": "ts-node src/index.ts"
   },

--- a/scripts/dev-repl.ts
+++ b/scripts/dev-repl.ts
@@ -1,0 +1,17 @@
+import { createRepl, create } from "ts-node";
+
+const repl = createRepl();
+const service = create({
+    ...repl.evalAwarePartialHost
+});
+repl.setService(service);
+repl.start();
+repl.evalCode(`
+import { GraphQLContext, contextFactory as c } from "./src/context";
+let context: GraphQLContext;
+
+console.log("welcome to the ctdb developer repl");
+console.log("> if you would like access to a GraphQL context,)
+console.log("> please run \`context = await c();\`");
+process.stdout.write("> ");
+`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2018",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
This small change allows a development TypeScript REPL to be started
through npm scripts with `npm run repl`. It provides a small amount of
boilierplate that can easily be added to, but due to the finnicky nature
of REPL async/await, that setup cannot be fully automated; a helpful
message about acquiring a GraphQLContext object is provided instead.