### PR TITLE
Run ctdb in docker 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 DATABASE_URL="postgres://username:password@localhost:5432/ctdb"
+POSTGRES_PASSWORD="password"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Start with a Docker image running the latest version of node.
+FROM node:latest
+
+# Set timezone
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Copy over source code and migrations and config necessary to run the GraphQL API
+WORKDIR /ctdb
+COPY ./prisma ./prisma
+COPY ./src ./src
+COPY ./package.json ./
+COPY ./tsconfig.json ./
+
+# Install npm packages as necessary
+RUN npm install
+
+# Expose port used to serve GraphQL API
+EXPOSE 3000
+
+# Tell Docker to start this container by setting the environment variable and then running any migrations and then starting the GraphQL server. 
+ENTRYPOINT export DATABASE_URL="postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/ctdb" && npx prisma migrate dev && npm start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+# Docker compose file to orchestrate bringing ctdb up and down
+
+version: "3.1"
+
+services:
+  db:
+    container_name: ctdb_postgres
+    image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_DB: "ctdb"
+    volumes:
+      - "postgres_data:/var/lib/postgresql/data"
+  api:
+    build: .
+    depends_on:
+      - db
+    environment:
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+    ports:
+      - "3000:3000"
+
+    
+volumes:
+  postgres_data:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,29 @@
+# Info about Docker setup.
+
+## What is docker?
+
+Docker is a containerization tool that makes it easy to reproduce builds of a piece of software. Docker-compose 
+is a tool that comes with Docker and makes it possible to orchestrate the creation and management of several docker
+containers at once. To install docker, go to <https://docs.docker.com/engine/install/>. 
+
+## How is docker used in ctdb?
+
+Ctdb has two files related to docker. The first, `Dockerfile` is instructions for docker to create/recreate a 
+container with ctdb in it and then start it when asked to. The second is `docker-compose.yml`. `docker-compose.yml`
+has instructions for docker to create two docker containers and one docker volume. A docker volume is a datastore that 
+persists on the hard disk even if the docker container is shut down or deleted. The containers created by `docker-compose.yml`
+include ctdb itself and then an instance of Postgres to act as the database for ctdb. You do not need to have Postgres or 
+ctdb running on your local machine -- they both run in docker. The volume created is for the Postgres data, so that it is
+not lost during reboots. 
+
+## How do I use docker as a developer of ctdb?
+
+Once you have docker installed, you should set a Postgres password in your `.env` file. For example:
+```
+POSTGRES_PASSWORD=hunter2
+```
+
+After this you can simply run `docker-compose up --build -d` and check `http://localhost:3000/graphql` once the command 
+completes. To pull down the docker containers, run `docker-compose down`. Remember to bring the docker containers down
+and then back up again to see any changes you make, since the container actually contains a copy of all the source code 
+and migrations, and will not reflect changes to the original without being rebuilt. 

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "@typescript-eslint/parser": "^5.16.0",
     "eslint": "^8.11.0",
     "prisma": "^3.9.2",
-    "ts-node": "^10.4.0",
-    "ts-node-dev": "^1.1.8",
-    "typescript": "^4.5.3"
+    "ts-node": "^10.9.1",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^4.7"
   },
   "dependencies": {
     "@graphql-tools/load-files": "^6.5.4",


### PR DESCRIPTION
This PR updates a few dependencies as necessary to get a functional docker build. It also adds an item (`POSTGRES_PASSWORD`) to the `.env` file but this is only necessary to run ctdb in docker. Running ctdb outside of docker is unaffected. The `Dockerfile` here will copy all necessary files to run ctdb into a docker container, install node dependencies, and then tell docker what to run and what ports to expose to run ctdb. This is paired with the `docker-compose.yml` file such that when a developer runs `docker-compose up` an instance of Postgres spins up in a docker container, with a persistent data volume created or attached as necessary, and then ctdb runs and is exposed at `localhost:3000/graphql` of the host machine. 