### PR TITLE
Extend functionality of Elo calculation pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "intake": "dotenv -e .env.development -- ts-node scripts/intake/index.ts"
   },
   "prisma": {
-    "seeed": "dotenv -e .env.development -- ts-node prisma/seed.ts"
+    "seed": "dotenv -e .env.development -- ts-node prisma/seed.ts"
   },
   "keywords": [],
   "author": "",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -11,6 +11,9 @@ const matchCount = 100;
 // TODO: Add more seeds in here, maybe add randomization too
 // TODO: Abstractions possible with model attributes
 
+const dateLow = new Date(2020, 0, 1).toISOString();
+const dateHigh = new Date(2023, 0, 1).toISOString();
+
 function randomResults(playerId1: string, playerId2: string) {
   const scores = [
     Math.floor(Math.random() * 1300000),
@@ -53,7 +56,7 @@ function randomGames(playerId1: string, playerId2: string) {
     const results = randomResults(playerId1, playerId2);
 
     games.push({
-      timestamp: new Date(),
+      timestamp: faker.date.between(dateLow, dateHigh),
       results: {
         create: results,
       }
@@ -67,7 +70,7 @@ function randomGames(playerId1: string, playerId2: string) {
 function randomMatch(playerId1: string, playerId2: string) {
   return {
     rom: RomVersion.NTSC,
-    timestamp: new Date(),
+    timestamp: faker.date.between(dateLow, dateHigh),
     type: MatchType.FRIENDLY,
     games: {
       create: randomGames(playerId1, playerId2)

--- a/src/elo/pipeline/index.ts
+++ b/src/elo/pipeline/index.ts
@@ -7,11 +7,12 @@ import { updateComputedElo } from "./update";
 
 export const eloPipeline = async (
   oldestMatchId: string,
-  context: GraphQLContext
+  context: GraphQLContext,
+  newestMatchId?: string
 ) => {
 
   // pull matches from database
-  const matches = await pullMatches(oldestMatchId, context);
+  const matches = await pullMatches(oldestMatchId, context, newestMatchId);
 
   // pull computed elos from database based on matches
   const computedElos = await getComputedEloFromMatches(matches, context);

--- a/src/elo/pipeline/index.ts
+++ b/src/elo/pipeline/index.ts
@@ -7,12 +7,11 @@ import { updateComputedElo } from "./update";
 
 export const eloPipeline = async (
   oldestMatchId: string,
-  context: GraphQLContext,
-  newestMatchId?: string
+  context: GraphQLContext
 ) => {
 
   // pull matches from database
-  const matches = await pullMatches(oldestMatchId, context, newestMatchId);
+  const matches = await pullMatches(oldestMatchId, context);
 
   // pull computed elos from database based on matches
   const computedElos = await getComputedEloFromMatches(matches, context);

--- a/src/elo/util/dbInterface.ts
+++ b/src/elo/util/dbInterface.ts
@@ -180,8 +180,8 @@ export const writeEloSnapshots = async (
           versionId: snapshot.versionId,
         },
       },
-      // do not update existing snapshot
-      update: { },
+      // update existing snapshot if it exists
+      update: snapshot,
       create: snapshot,
     })
   );

--- a/src/elo/util/dbInterface.ts
+++ b/src/elo/util/dbInterface.ts
@@ -53,8 +53,7 @@ export const pullComputedElos = async (
 
 export const pullMatches = async (
   oldestMatchId: string,
-  context: GraphQLContext,
-  newestMatchId?: string
+  context: GraphQLContext
 ): Promise<MatchIM[]> => {
 
   const oldestMatch = await context.prisma.match.findUnique({
@@ -63,13 +62,7 @@ export const pullMatches = async (
     }
   });
 
-  const newestMatch = newestMatchId ? await context.prisma.match.findUnique({
-    where: {
-      id: newestMatchId
-    }
-  }) : null;
-
-  if (!oldestMatch || (newestMatchId && !newestMatch))
+  if (!oldestMatch)
     return [];
 
   // get all matches newer than oldestMatch and older than newestMatch (if
@@ -78,8 +71,6 @@ export const pullMatches = async (
     where: {
       timestamp: {
         gte: oldestMatch.timestamp,
-        // only add a "less than or equal to" filter if newestMatch exists
-        ...(newestMatch && { lte: newestMatch.timestamp })
       }
     },
     include: {

--- a/src/elo/util/dbInterface.ts
+++ b/src/elo/util/dbInterface.ts
@@ -88,6 +88,9 @@ export const pullMatches = async (
           results: true,
         }
       }
+    },
+    orderBy: {
+      timestamp: "asc",
     }
   });
 

--- a/src/resolvers/Match.ts
+++ b/src/resolvers/Match.ts
@@ -12,7 +12,6 @@ const match = {
     }).games();
   },
 
-<<<<<<< HEAD
   event: async (
     parent: Match,
     context: GraphQLContext
@@ -21,7 +20,6 @@ const match = {
       where: { id: parent.eventId || undefined },
     });
   },
-=======
   //TODO: put this back once fix id:parent.eventId
   // event: async (
   //   parent: Match,
@@ -31,7 +29,6 @@ const match = {
   //     where: { id: parent.eventId },
   //   });
   // },
->>>>>>> e8af5aa (WIP: stuff and things)
 
   eloChanges: async (
     parent: Match,


### PR DESCRIPTION
Essentially just (2) and (3) of this project task.
- https://github.com/users/professor-l/projects/1/views/1?pane=issue&itemId=12598765

`eloPipeline` and `pullMatches` now takes in an optional parameter `newestMatch` to allow calculation w.r.t. 1 segment only. To allow for more rigid testing, `seed.ts` has been updated so game and match timestamps are randomly generated. (Previously, the timestamp is the exact current time and the effect was hard to observe since lots of matches had the same timestamp.)

`EloSnapshot` is only created if no duplicate is found on the current database.

`pullMatches` now pulls matches in chronological order of timestamp.