### PR TITLE
Rename query to reflect behavior

### DIFF
--- a/src/graphql_schema/query.graphql
+++ b/src/graphql_schema/query.graphql
@@ -16,7 +16,7 @@ type Query {
     getMatchesByPlayer(eloName: String): [Match!]!
 
     # Players
-    getPlayerByName(eloName: String!): Player
+    getPlayerByEloName(eloName: String!): Player
     getPlayerById(id: String!): Player
     # TODO: Privileged query
     getAllPlayers: [Player!]!

--- a/src/query/getPlayerByEloName.ts
+++ b/src/query/getPlayerByEloName.ts
@@ -1,6 +1,6 @@
 import { GraphQLContext } from "../context";
 
-const getPlayerByName = async (
+const getPlayerByEloName = async (
   parent: unknown,
   args: { eloName: string, },
   context: GraphQLContext
@@ -14,4 +14,4 @@ const getPlayerByName = async (
 
 };
 
-export default getPlayerByName;
+export default getPlayerByEloName;

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -11,7 +11,7 @@ import getEventsByEdition from "./getEventsByEdition";
 import getAllMatches from "./getAllMatches";
 import getMatchesByPlayer from "./getMatchesByPlayer";
 
-import getPlayerByName from "./getPlayerByName";
+import getPlayerByEloName from "./getPlayerByEloName";
 import getPlayerById from "./getPlayerById";
 import getAllPlayers from "./getAllPlayers";
 
@@ -28,7 +28,7 @@ const query = {
   getAllMatches,
   getMatchesByPlayer,
 
-  getPlayerByName,
+  getPlayerByEloName,
   getPlayerById,
   getAllPlayers,
 };

--- a/test/getters.ts
+++ b/test/getters.ts
@@ -325,13 +325,13 @@ export const testGetters = () => describe("Test getters", () => {
     });
   });
 
-  describe("getPlayerByName", () => {
+  describe("getPlayerByEloName", () => {
     it ("should return player", async () => {
       const query = gql`
         query(
           $eloName: String!
         ){
-          getPlayerByName(
+          getPlayerByEloName(
             eloName: $eloName
           ){
             id
@@ -351,7 +351,7 @@ export const testGetters = () => describe("Test getters", () => {
         },
       });
       const parsed = JSON.parse(response["body"]);
-      expect(parsed.data.getPlayerByName).toMatchObject(
+      expect(parsed.data.getPlayerByEloName).toMatchObject(
         {
           id: state.PLAYER1.id,
           eloName: state.PLAYER1.eloName,

--- a/test/resolvers.ts
+++ b/test/resolvers.ts
@@ -16,7 +16,7 @@ export const testResolvers = () => describe("Test resolvers", () => {
     it("should resolve player", async () => {
       const query = gql`
         query ($eloName: String!) {
-          getPlayerByName(eloName: $eloName) {
+          getPlayerByEloName(eloName: $eloName) {
             eloHistory {
               id
               version
@@ -311,7 +311,7 @@ export const testResolvers = () => describe("Test resolvers", () => {
     it("should resolve results", async () => {
       const query = gql`
         query ($eloName: String!) {
-          getPlayerByName(eloName: $eloName) {
+          getPlayerByEloName(eloName: $eloName) {
             results {
               id
             }
@@ -324,7 +324,7 @@ export const testResolvers = () => describe("Test resolvers", () => {
         variables: { eloName: state.PLAYER1.eloName }
       });
       const parsed = JSON.parse(response["body"]);
-      const resultIds = parsed.data.getPlayerByName.results
+      const resultIds = parsed.data.getPlayerByEloName.results
         .map((result: { id: string }) => result.id);
       expect(resultIds).toEqual(
         expect.arrayContaining([ state.RESULT1.id, state.RESULT3.id ])


### PR DESCRIPTION
This simple change renames the `getPlayerByName` query to instead be `getPlayerByEloName`, to reflect that we must use the EloName of the player, which is necessarily unique. This is a name change but otherwise a no-op.